### PR TITLE
Added testing for the Home screen

### DIFF
--- a/client/src/screens/HomeScreen.jsx
+++ b/client/src/screens/HomeScreen.jsx
@@ -8,8 +8,8 @@ import StyledButton from '../components/StyledButton';
 function HomeScreen() {
   return (
     <>
-      <p>Welcome to the AWS Quiz!</p>
-      <p>You will be given the logo of multiple AWS services, can you name them all?</p>
+      <p data-testid="welcome-text">Welcome to the AWS Quiz!</p>
+      <p data-testid="info-text">You will be given the logo of multiple AWS services, can you name them all?</p>
       <MenuButtons />
     </>
   );
@@ -23,7 +23,7 @@ function MenuButtons() {
   };
 
   return (
-    <ButtonGroup varient="text">
+    <ButtonGroup data-testid="menu-buttons" varient="text">
       <StyledButton label="Easy" onClick={() => routeChange('/quiz')} />
       <StyledButton label="Medium" />
       <StyledButton label="Hard" />

--- a/client/src/tests/HomeScreen.test.jsx
+++ b/client/src/tests/HomeScreen.test.jsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { createMemoryRouter, RouterProvider } from 'react-router-dom';
+import HomeScreen from '../screens/HomeScreen';
+
+function memoryRouterSetup() {
+  const routes = [{
+    path: '/quiz',
+    element: <p>Dummy quiz page</p>,
+  },
+  {
+    path: '/',
+    element: <HomeScreen />,
+  }];
+
+  const router = createMemoryRouter(routes, {
+    initialEntries: ['/'],
+    initialIndex: 0,
+  });
+
+  render(
+    <RouterProvider router={router} />,
+  );
+}
+
+describe('Home screen', () => {
+  beforeEach(memoryRouterSetup);
+
+  it('should render welcome text', () => {
+    const welcomeText = screen.getByTestId('welcome-text');
+    expect(welcomeText.innerHTML).toEqual('Welcome to the AWS Quiz!');
+  });
+
+  it('should render information text', () => {
+    const infoText = screen.getByTestId('info-text');
+    expect(infoText.innerHTML).toEqual('You will be given the logo of multiple AWS services, can you name them all?');
+  });
+
+  it('should render menu button group', () => {
+    const menuButtons = screen.getByTestId('menu-buttons');
+    expect(menuButtons).toBeTruthy();
+  });
+
+  describe('Easy button', () => {
+    it('should render with \'Easy\' label', () => {
+      const menuButtons = screen.getByTestId('menu-buttons');
+      const easyButton = menuButtons.children[0];
+      expect(easyButton.innerHTML).toContain('Easy');
+    });
+
+    it('should change path to /quiz when clicked', () => {
+      const menuButtons = screen.getByTestId('menu-buttons');
+      const easyButton = menuButtons.children[0];
+      userEvent.click(easyButton);
+      const quizPageText = screen.getByText('Dummy quiz page');
+      expect(quizPageText).toBeTruthy();
+    });
+  });
+
+  describe('Medium button', () => {
+    it('should render with \'Medium\' label', () => {
+      const menuButtons = screen.getByTestId('menu-buttons');
+      const mediumButton = menuButtons.children[1];
+      expect(mediumButton.innerHTML).toContain('Medium');
+    });
+  });
+
+  describe('Hard button', () => {
+    it('should render with \'Hard\' label', () => {
+      const menuButtons = screen.getByTestId('menu-buttons');
+      const hardButton = menuButtons.children[2];
+      expect(hardButton.innerHTML).toContain('Hard');
+    });
+  });
+});


### PR DESCRIPTION
Closes #52 
- Added data-testid property to components within HomeScreen.jsx so they can be referenced in the tests.
- Created file HomeScreen.test.jsx:
  - Added a memory router, which essentially acts as a mock router for the purpose of the tests. Allows the tests to control the paths and their content.
  - Setup is kept in memoryRouterSetup and triggered in beforeEach()
  - Main components and text checked that they render properly
  - Checked that when the easy button is clicked, that the path changes to '/quiz'. This will need adding for other buttons when they are eventually implemented.